### PR TITLE
Resolved linker errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 
 install:
-      - cwd
+      - pwd
       - ls -la
       - mkdir -p ~/source
       - cd ~/source

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
       - make install
       
 script:
-      - cd ~
+      - cd /home/travis/build/mjirous/cinject
       - ls -la
       - cmake -DCMAKE_BUILD_TYPE=release -DBUILD_TESTS=ON -DGTEST_ROOT=~/lib/gtest/1.8.0
       - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
       - make install
       
 script:
+      - cd ~
       - ls -la
       - cmake -DCMAKE_BUILD_TYPE=release -DBUILD_TESTS=ON -DGTEST_ROOT=~/lib/gtest/1.8.0
       - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: trusty
 sudo: required
 
 install:
+      - cwd
+      - ls -la
       - mkdir -p ~/source
       - cd ~/source
       - git clone -b release-1.8.0 https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+
+dist: trusty
+sudo: required
+
+install:
+      - mkdir -p ~/source
+      - cd ~/source
+      - git clone -b release-1.8.0 https://github.com/google/googletest.git
+      - ls -la
+      - mkdir -p ~/source/googletest/build
+      - cd ~/source/googletest/build
+      - cmake -DCMAKE_BUILD_TYPE=release -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DCMAKE_INSTALL_PREFIX=~/lib/gtest/1.8.0 ..
+      - make
+      - make install
+      
+script:
+      - ls -la
+      - cmake -DCMAKE_BUILD_TYPE=release -DBUILD_TESTS=ON -DGTEST_ROOT=~/lib/gtest/1.8.0
+      - make
+      - make test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Cinject #
+[![Build Status](https://travis-ci.org/mjirous/cinject.svg?branch=master)](https://travis-ci.org/mjirous/cinject)
+
 
 Welcome to Cinject, a cross platform C++ dependency injection framework built using c++ 11.
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@ Welcome to Cinject, a cross platform C++ dependency injection framework built up
 
 Cinject is a very simple C++ dependency injection framework built with features from C++ 11 like **variadic templates**, **shared_ptr** and **type traits**. Cinject implementation is header-only in single header file that simplifies integration with any project. Inspired by the [ninject](http://www.ninject.org/) Cinject provides very similar and comprehensive API.
 
-* include/Cinject
+### Project structure ###
 
-Cinject implementation, to be included in your project.
-
-* src/
-
-Contains complex example of Cinject usage demonstrating its features.
-
-* test/
-
-Unit tests of Cinject (requires [google test]( https://github.com/google/googletest ))
+* include/cinject - Cinject implementation, to be included in your project.
+* src/ - Contains complex example of Cinject usage demonstrating its features.
+* test/ - Unit tests of Cinject (requires [google test]( https://github.com/google/googletest ))
 
 ### Features ###
 

--- a/include/cinject/cinject.h
+++ b/include/cinject/cinject.h
@@ -494,7 +494,7 @@ public:
 
     }
 
-    void InSingletonScope()
+    void inSingletonScope()
     {
         storage_->setSingleton(true);
     }
@@ -617,7 +617,7 @@ public:
     {}
 };
 
-// Specialization for single component registration that allows the ToSelf
+// Specialization for single component registration that allows the toSelf
 template<typename TImplementation>
 class ComponentBuilder<TImplementation> : public ComponentBuilderBase<TImplementation>
 {
@@ -626,7 +626,7 @@ public:
         ComponentBuilderBase<TImplementation>(container)
     {}
 
-    StorageConfiguration<InstanceStorage<TImplementation, ConstructorFactory<TImplementation>>> ToSelf()
+    StorageConfiguration<InstanceStorage<TImplementation, ConstructorFactory<TImplementation>>> toSelf()
     {
         return ComponentBuilderBase<TImplementation>::template to<TImplementation>();
     }

--- a/src/cinject_test_app.cpp
+++ b/src/cinject_test_app.cpp
@@ -223,15 +223,15 @@ int main()
     Container c;
 
     // Singletons
-    c.bind<IWalker, IRunner, IJumper, ICrawler, ISwimmer, IWaterConsumer, Human>().to<Human>().InSingletonScope();
-    c.bind<ICrawler, IWaterConsumer, Snake>().to<Snake>().InSingletonScope();
-    c.bind<IWalker, ICrawler, ISwimmer, IWaterConsumer, Turtle>().to<Turtle>().InSingletonScope();
-    c.bind<IWalker, IRunner, IJumper, IFlyer, IWaterConsumer, Bird>().to<Bird>().InSingletonScope();
+    c.bind<IWalker, IRunner, IJumper, ICrawler, ISwimmer, IWaterConsumer, Human>().to<Human>().inSingletonScope();
+    c.bind<ICrawler, IWaterConsumer, Snake>().to<Snake>().inSingletonScope();
+    c.bind<IWalker, ICrawler, ISwimmer, IWaterConsumer, Turtle>().to<Turtle>().inSingletonScope();
+    c.bind<IWalker, IRunner, IJumper, IFlyer, IWaterConsumer, Bird>().to<Bird>().inSingletonScope();
 
     // Not singletons
-    c.bind<Legs>().ToSelf();
-    c.bind<Arms>().ToSelf();
-    c.bind<Wings>().to<Wings>(); //Same as ToSelf
+    c.bind<Legs>().toSelf();
+    c.bind<Arms>().toSelf();
+    c.bind<Wings>().to<Wings>(); //Same as toSelf
 
     // Manual creation of object. Not singleton, but it could be by calling InSingleTonScope
     c.bind<Behavior>().toFunction<Behavior>([](InjectionContext* ctx)

--- a/test/cinject_test.cpp
+++ b/test/cinject_test.cpp
@@ -40,7 +40,7 @@ namespace SimpleResolve
     TEST(CInjectTest, TestSimpleResolve__Singleton)
     {
         Container c;
-        c.bind<IRunner>().to<Cheetah>().InSingletonScope();
+        c.bind<IRunner>().to<Cheetah>().inSingletonScope();
 
         std::shared_ptr<IRunner> runner = c.get<IRunner>();
         std::shared_ptr<IRunner> runner2 = c.get<IRunner>();
@@ -70,7 +70,7 @@ namespace SimpleResolve
     TEST(CInjectTest, TestSimpleResolve_ToSelf__Singleton)
     {
         Container c;
-        c.bind<Cheetah>().to<Cheetah>().InSingletonScope();
+        c.bind<Cheetah>().to<Cheetah>().inSingletonScope();
 
         std::shared_ptr<Cheetah> runner = c.get<Cheetah>();
         std::shared_ptr<Cheetah> runner2 = c.get<Cheetah>();
@@ -103,7 +103,7 @@ namespace SimpleResolve
         cinject::Container c;
         c.bind<IRunner>()
             .toFunction<Cheetah>([](InjectionContext*) { return std::make_shared<Cheetah>(); })
-            .InSingletonScope();
+            .inSingletonScope();
 
         std::shared_ptr<IRunner> runner = c.get<IRunner>();
         std::shared_ptr<IRunner> runner2 = c.get<IRunner>();
@@ -192,7 +192,7 @@ namespace MultipleInterfaces
     TEST(CInjectTest, TestMultipleInterfaces__Singleton)
     {
         Container c;
-        c.bind<IWalker, IJumper, IRunner>().to<Cheetah>().InSingletonScope();
+        c.bind<IWalker, IJumper, IRunner>().to<Cheetah>().inSingletonScope();
 
         std::shared_ptr<IRunner> runner = c.get<IRunner>();
         std::shared_ptr<IWalker> walker = c.get<IWalker>();
@@ -239,8 +239,8 @@ namespace NestedDependencies
     TEST(CInjectTest, TestNestedDependencies)
     {
         Container c;
-        c.bind<Spider>().ToSelf();
-        c.bind<INest>().to<SpiderNest>().InSingletonScope();
+        c.bind<Spider>().toSelf();
+        c.bind<INest>().to<SpiderNest>().inSingletonScope();
 
         std::shared_ptr<Spider> spider1 = c.get<Spider>();
         std::shared_ptr<Spider> spider2 = c.get<Spider>();
@@ -333,7 +333,7 @@ namespace NestedDependenciesWithVector
         c.bind<ISnake>().to<Mamba>();
         c.bind<ISnake>().to<Viper>();
         c.bind<IMaterial>().to<Paper>();
-        c.bind<IEncyclopedy>().to<SnakeEncyclopedy>().InSingletonScope();
+        c.bind<IEncyclopedy>().to<SnakeEncyclopedy>().inSingletonScope();
 
         std::shared_ptr<IEncyclopedy> encyclopedy = c.get<IEncyclopedy>();
         std::shared_ptr<IMaterial> material = c.get<IMaterial>();
@@ -425,10 +425,10 @@ namespace ResolveCollection
     {
         Container c;
 
-        c.bind<ISnake>().to<GrassSnake>().InSingletonScope();
-        c.bind<ISnake>().to<Python>().InSingletonScope();
-        c.bind<ISnake>().to<Mamba>().InSingletonScope();
-        c.bind<ISnake>().to<Viper>().InSingletonScope();
+        c.bind<ISnake>().to<GrassSnake>().inSingletonScope();
+        c.bind<ISnake>().to<Python>().inSingletonScope();
+        c.bind<ISnake>().to<Mamba>().inSingletonScope();
+        c.bind<ISnake>().to<Viper>().inSingletonScope();
 
         std::shared_ptr<ISnake> snake = c.get<ISnake>();
 
@@ -466,10 +466,10 @@ namespace ResolveCollection
     {
         Container c;
 
-        c.bind<ISnake>().to<GrassSnake>().InSingletonScope();
-        c.bind<ISnake>().to<Python>().InSingletonScope();
-        c.bind<ISnake>().to<Mamba>().InSingletonScope();
-        c.bind<ISnake>().to<Viper>().InSingletonScope();
+        c.bind<ISnake>().to<GrassSnake>().inSingletonScope();
+        c.bind<ISnake>().to<Python>().inSingletonScope();
+        c.bind<ISnake>().to<Mamba>().inSingletonScope();
+        c.bind<ISnake>().to<Viper>().inSingletonScope();
 
         std::vector<std::shared_ptr<ISnake>> allSnakes = c.get<std::vector<std::shared_ptr<ISnake>>>();
 
@@ -515,7 +515,7 @@ namespace BindManyToOne
         Container c;
 
         // intentional order to not match the function implementation order
-        c.bind<IRunner, IJumper, IWalker>().to<Human>().InSingletonScope();
+        c.bind<IRunner, IJumper, IWalker>().to<Human>().inSingletonScope();
 
         std::shared_ptr<IWalker> walker = c.get<IWalker>();
         std::shared_ptr<IRunner> runner = c.get<IRunner>();
@@ -559,9 +559,9 @@ namespace CircularDependency
         Container c;
 
         // intentional order to not match the function implementation order
-        c.bind<Start>().ToSelf();
-        c.bind<Middle>().ToSelf();
-        c.bind<End>().ToSelf();
+        c.bind<Start>().toSelf();
+        c.bind<Middle>().toSelf();
+        c.bind<End>().toSelf();
 
         ASSERT_THROW(c.get<Start>(), CircularDependencyFound);
     }
@@ -572,8 +572,8 @@ namespace CircularDependency
 
         // intentional order to not match the function implementation order
         c.bind<Start>().toFunction<Start>([](InjectionContext* c) { return std::make_shared<Start>(c->getContainer().get<Middle>(c)); });
-        c.bind<Middle>().ToSelf();
-        c.bind<End>().ToSelf();
+        c.bind<Middle>().toSelf();
+        c.bind<End>().toSelf();
 
         ASSERT_THROW(c.get<Start>(), CircularDependencyFound);
     }
@@ -691,10 +691,10 @@ namespace ContainerHierarchy
     {
         Container c;
 
-        c.bind<City>().ToSelf().InSingletonScope();
+        c.bind<City>().toSelf().inSingletonScope();
 
         Container child(&c);
-        child.bind<Building>().ToSelf().InSingletonScope();
+        child.bind<Building>().toSelf().inSingletonScope();
 
 
         std::shared_ptr<Building> building = child.get<Building>();
@@ -743,12 +743,12 @@ namespace ContainerHierarchyWithCollection
     {
         Container c;
 
-        c.bind<IAnimal>().to<Fish>().InSingletonScope();
-        c.bind<IAnimal>().to<Bird>().InSingletonScope();
+        c.bind<IAnimal>().to<Fish>().inSingletonScope();
+        c.bind<IAnimal>().to<Bird>().inSingletonScope();
 
         Container child(&c);
-        child.bind<IAnimal>().to<Snake>().InSingletonScope();
-        child.bind<IAnimal>().to<Cheetah>().InSingletonScope();
+        child.bind<IAnimal>().to<Snake>().inSingletonScope();
+        child.bind<IAnimal>().to<Cheetah>().inSingletonScope();
 
 
         std::vector<std::shared_ptr<IAnimal>> animalsFromRoot = c.get<std::vector<IAnimal>>();


### PR DESCRIPTION
Fixed following issues:
- Added missing #pragma once to guard against multiple includes in the same translation unit
- Fixed Qt moc handling of cinject.h by disabling its processing of the file
- Fixed two linker errors due to two inline methods (one free function and one method) defined outside of class scope that were not marked as inline - that caused multiply defined symbols when cinject.h was used in more than one translation unit file (see https://stackoverflow.com/questions/1568807/how-to-define-non-method-functions-in-header-libraries)